### PR TITLE
Handle Trap while calling wasm function

### DIFF
--- a/src/main/java/io/github/kawamuray/wasmtime/Func.java
+++ b/src/main/java/io/github/kawamuray/wasmtime/Func.java
@@ -36,10 +36,24 @@ public class Func implements Disposable {
         return newFunc(store.innerPtr(), fnType, index);
     }
 
+    /**
+     * Call this function with given variadic arguments
+     * @param args a collection of argument values passed to the callee function
+     * @return a list of returned values
+     * @throws TrapException if the function throws an exception or exits with WASI API
+     * @throws WasmtimeException if the wasmtime runtime throws an internal exception
+     */
     public Val[] call(Val... args) {
         return nativeCall(args);
     }
 
+    /**
+     * Call this function with a given list of arguments
+     * @param args a collection of argument values passed to the callee function
+     * @return a list of returned values
+     * @throws TrapException if the function throws an exception or exits with WASI API
+     * @throws WasmtimeException if the wasmtime runtime throws an internal exception
+     */
     public List<Val> call(Collection<Val> args) {
         return Arrays.asList(call(args.toArray(EMPTY_VALS)));
     }

--- a/src/main/java/io/github/kawamuray/wasmtime/Func.java
+++ b/src/main/java/io/github/kawamuray/wasmtime/Func.java
@@ -36,11 +36,11 @@ public class Func implements Disposable {
         return newFunc(store.innerPtr(), fnType, index);
     }
 
-    public Val[] call(Val... args) {
+    public Val[] call(Val... args) throws Trap {
         return nativeCall(args);
     }
 
-    public List<Val> call(Collection<Val> args) {
+    public List<Val> call(Collection<Val> args) throws Trap {
         return Arrays.asList(call(args.toArray(EMPTY_VALS)));
     }
 
@@ -71,5 +71,5 @@ public class Func implements Disposable {
 
     private static native long newFunc(long storePtr, FuncType fnType, int index);
 
-    private native Val[] nativeCall(Val[] args);
+    private native Val[] nativeCall(Val[] args) throws Trap;
 }

--- a/src/main/java/io/github/kawamuray/wasmtime/Func.java
+++ b/src/main/java/io/github/kawamuray/wasmtime/Func.java
@@ -36,11 +36,11 @@ public class Func implements Disposable {
         return newFunc(store.innerPtr(), fnType, index);
     }
 
-    public Val[] call(Val... args) throws Trap {
+    public Val[] call(Val... args) {
         return nativeCall(args);
     }
 
-    public List<Val> call(Collection<Val> args) throws Trap {
+    public List<Val> call(Collection<Val> args) {
         return Arrays.asList(call(args.toArray(EMPTY_VALS)));
     }
 
@@ -71,5 +71,5 @@ public class Func implements Disposable {
 
     private static native long newFunc(long storePtr, FuncType fnType, int index);
 
-    private native Val[] nativeCall(Val[] args) throws Trap;
+    private native Val[] nativeCall(Val[] args);
 }

--- a/src/main/java/io/github/kawamuray/wasmtime/Trap.java
+++ b/src/main/java/io/github/kawamuray/wasmtime/Trap.java
@@ -1,7 +1,6 @@
 package io.github.kawamuray.wasmtime;
 
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.NonNull;
 import lombok.Value;
 import lombok.experimental.Accessors;

--- a/src/main/java/io/github/kawamuray/wasmtime/Trap.java
+++ b/src/main/java/io/github/kawamuray/wasmtime/Trap.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.NonNull;
 
 @AllArgsConstructor
-public class Trap {
+public class Trap extends RuntimeException {
     public enum Type {
         MESSAGE,
         I32_EXIT,
@@ -24,5 +24,12 @@ public class Trap {
 
     public static Trap fromException(Throwable e) {
         return fromMessage(String.valueOf(e));
+    }
+
+    public Type type() {
+        return this.type;
+    }
+    public int exitCode() {
+        return this.exitCode;
     }
 }

--- a/src/main/java/io/github/kawamuray/wasmtime/Trap.java
+++ b/src/main/java/io/github/kawamuray/wasmtime/Trap.java
@@ -1,18 +1,23 @@
 package io.github.kawamuray.wasmtime;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NonNull;
+import lombok.Value;
+import lombok.experimental.Accessors;
 
+@Value
+@Accessors(fluent = true)
 @AllArgsConstructor
-public class Trap extends RuntimeException {
+public class Trap {
     public enum Type {
         MESSAGE,
         I32_EXIT,
     }
 
-    private final Type type;
-    private final String message;
-    private final int exitCode;
+    Type type;
+    String message;
+    int exitCode;
 
     public static Trap fromMessage(@NonNull String message) {
         return new Trap(Type.MESSAGE, message, 0);
@@ -24,12 +29,5 @@ public class Trap extends RuntimeException {
 
     public static Trap fromException(Throwable e) {
         return fromMessage(String.valueOf(e));
-    }
-
-    public Type type() {
-        return this.type;
-    }
-    public int exitCode() {
-        return this.exitCode;
     }
 }

--- a/src/main/java/io/github/kawamuray/wasmtime/TrapException.java
+++ b/src/main/java/io/github/kawamuray/wasmtime/TrapException.java
@@ -1,12 +1,15 @@
 package io.github.kawamuray.wasmtime;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 
-@AllArgsConstructor
 @Accessors(fluent = true)
-public class TrapException extends RuntimeException {
+public class TrapException extends WasmtimeException {
     @Getter
     private final Trap trap;
+
+    TrapException(Trap trap) {
+        super(trap.message());
+        this.trap = trap;
+    }
 }

--- a/src/main/java/io/github/kawamuray/wasmtime/TrapException.java
+++ b/src/main/java/io/github/kawamuray/wasmtime/TrapException.java
@@ -1,0 +1,12 @@
+package io.github.kawamuray.wasmtime;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@AllArgsConstructor
+@Accessors(fluent = true)
+public class TrapException extends RuntimeException {
+    @Getter
+    private final Trap trap;
+}

--- a/src/test/java/io/github/kawamuray/wasmtime/FuncTest.java
+++ b/src/test/java/io/github/kawamuray/wasmtime/FuncTest.java
@@ -69,7 +69,7 @@ public class FuncTest {
         }
     }
 
-    @Test(expected = Trap.class)
+    @Test(expected = TrapException.class)
     public void testTrampolineTrap() {
         FuncType fnType = new FuncType(new Type[] { Type.I64, Type.I64 }, new Type[] { Type.I64 });
         try (Store store = new Store();
@@ -84,7 +84,7 @@ public class FuncTest {
         }
     }
 
-    @Test(expected = Trap.class)
+    @Test(expected = TrapException.class)
     public void testTrampolineException() {
         FuncType fnType = new FuncType(new Type[] { Type.I64, Type.I64 }, new Type[] { Type.I64 });
         try (Store store = new Store();
@@ -123,7 +123,8 @@ public class FuncTest {
             linker.module("", module);
             try (Func func = linker.getOneByName("", "_start").func()) {
                 func.call();
-            } catch (Trap trap) {
+            } catch (TrapException e) {
+                Trap trap = e.trap();
                 assertEquals(trap.type(), Trap.Type.I32_EXIT);
                 assertEquals(trap.exitCode(), 42);
             }

--- a/wasmtime-jni/src/errors.rs
+++ b/wasmtime-jni/src/errors.rs
@@ -1,3 +1,4 @@
+use crate::wtrap;
 use anyhow;
 use jni::descriptors::Desc;
 use jni::objects::JThrowable;
@@ -5,7 +6,6 @@ use jni::{self, JNIEnv};
 use std::io;
 use thiserror::Error;
 use wasi_common::WasiCtxBuilderError;
-use crate::wtrap;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -58,7 +58,12 @@ impl<'a> Desc<'a, JThrowable<'a>> for Error {
             ),
             WasmTrap(trap) => {
                 let jtrap = wtrap::into_java(env, trap)?;
-                return Ok(jtrap.into());
+                let jtrap_ex = env.new_object(
+                    "io/github/kawamuray/wasmtime/TrapException",
+                    "(Lio/github/kawamuray/wasmtime/Trap;)V",
+                    &[jtrap.into()],
+                )?;
+                return Ok(jtrap_ex.into());
             }
             WasiConfig(e) => (
                 "io/github/kawamuray/wasmtime/WasmtimeException",

--- a/wasmtime-jni/src/wtrap.rs
+++ b/wasmtime-jni/src/wtrap.rs
@@ -21,3 +21,26 @@ pub fn from_java(env: &JNIEnv, obj: JObject) -> Result<Trap> {
         _ => return Err(Error::UnknownEnum(name)),
     })
 }
+
+pub fn into_java<'a>(env: &JNIEnv<'a>, trap: &Trap) -> jni::errors::Result<JObject<'a>> {
+    if let Some(status) = trap.i32_exit_status() {
+        Ok(env
+            .call_static_method(
+                "io/github/kawamuray/wasmtime/Trap",
+                "fromExitCode",
+                "(I)Lio/github/kawamuray/wasmtime/Trap;",
+                &[status.into()],
+            )?
+            .l()?)
+    } else {
+        let jmsg = env.new_string(trap.to_string())?;
+        Ok(env
+            .call_static_method(
+                "io/github/kawamuray/wasmtime/Trap",
+                "fromMessage",
+                "(Ljava/lang/String;)Lio/github/kawamuray/wasmtime/Trap;",
+                &[jmsg.into()],
+            )?
+            .l()?)
+    }
+}


### PR DESCRIPTION
As you commented in TODO, the trap exception should be converted into its specific error to distinguish from wasmtime internal error.

https://github.com/kawamuray/wasmtime-java/blob/e2691194fd9414a1390dcc6d47b391a16801d0d3/wasmtime-jni/src/io_github_kawamuray_wasmtime_Func/imp.rs#L78-L79

This PR makes Java Trap class be a subclass of RuntimeException and throws it while calling wasm functions.