### PR TITLE
Add basic support for interrupt handlers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,7 @@ task generateJniInterfaces(type:JavaExec) {
             'io.github.kawamuray.wasmtime.Engine',
             'io.github.kawamuray.wasmtime.Func',
             'io.github.kawamuray.wasmtime.Instance',
+            'io.github.kawamuray.wasmtime.InterruptHandle',
             'io.github.kawamuray.wasmtime.Linker',
             'io.github.kawamuray.wasmtime.Memory',
             'io.github.kawamuray.wasmtime.Module',

--- a/src/main/java/io/github/kawamuray/wasmtime/InterruptHandle.java
+++ b/src/main/java/io/github/kawamuray/wasmtime/InterruptHandle.java
@@ -4,10 +4,8 @@ public class InterruptHandle {
     private final long innerPtr;
 
     public InterruptHandle(long storePtr) {
-        innerPtr = newInterruptHandle(storePtr);
+        innerPtr = storePtr;
     }
 
     public native void interrupt();
-
-    private native long newInterruptHandle(long storePtr);
 }

--- a/src/main/java/io/github/kawamuray/wasmtime/InterruptHandle.java
+++ b/src/main/java/io/github/kawamuray/wasmtime/InterruptHandle.java
@@ -1,11 +1,10 @@
 package io.github.kawamuray.wasmtime;
 
-public class InterruptHandle {
-    private final long innerPtr;
+import lombok.AllArgsConstructor;
 
-    public InterruptHandle(long interruptHandlerPtr) {
-        innerPtr = interruptHandlerPtr;
-    }
+@AllArgsConstructor
+public class InterruptHandle implements Disposable {
+    private final long innerPtr;
 
     public native void interrupt();
 }

--- a/src/main/java/io/github/kawamuray/wasmtime/InterruptHandle.java
+++ b/src/main/java/io/github/kawamuray/wasmtime/InterruptHandle.java
@@ -7,4 +7,7 @@ public class InterruptHandle implements Disposable {
     private final long innerPtr;
 
     public native void interrupt();
+
+    @Override
+    public native void dispose();
 }

--- a/src/main/java/io/github/kawamuray/wasmtime/InterruptHandle.java
+++ b/src/main/java/io/github/kawamuray/wasmtime/InterruptHandle.java
@@ -3,8 +3,8 @@ package io.github.kawamuray.wasmtime;
 public class InterruptHandle {
     private final long innerPtr;
 
-    public InterruptHandle(long storePtr) {
-        innerPtr = storePtr;
+    public InterruptHandle(long interruptHandlerPtr) {
+        innerPtr = interruptHandlerPtr;
     }
 
     public native void interrupt();

--- a/src/main/java/io/github/kawamuray/wasmtime/Store.java
+++ b/src/main/java/io/github/kawamuray/wasmtime/Store.java
@@ -50,6 +50,10 @@ public class Store<T> implements Disposable {
         return (T) storedData();
     }
 
+    public InterruptHandle interruptHandle() {
+        return new InterruptHandle(interruptHandlePtr());
+    }
+
     @Override
     public native void dispose();
 
@@ -60,4 +64,6 @@ public class Store<T> implements Disposable {
     private native Object storedData();
 
     public native void gc();
+
+    private native long interruptHandlePtr();
 }

--- a/wasmtime-jni/src/io_github_kawamuray_wasmtime_InterruptHandle/imp.rs
+++ b/wasmtime-jni/src/io_github_kawamuray_wasmtime_InterruptHandle/imp.rs
@@ -15,4 +15,9 @@ impl<'a> JniInterruptHandle<'a> for JniInterruptHandleImpl {
         interrupt_handle.interrupt();
         Ok(())
     }
+
+    fn dispose(env: &JNIEnv, this: JObject) -> Result<(), Self::Error> {
+        interop::dispose_inner::<InterruptHandle>(&env, this)?;
+        Ok(())
+    }
 }

--- a/wasmtime-jni/src/io_github_kawamuray_wasmtime_InterruptHandle/imp.rs
+++ b/wasmtime-jni/src/io_github_kawamuray_wasmtime_InterruptHandle/imp.rs
@@ -1,0 +1,18 @@
+use super::JniInterruptHandle;
+use crate::errors::{self, Result};
+use crate::interop;
+use jni::objects::JObject;
+use jni::JNIEnv;
+use wasmtime::InterruptHandle;
+
+pub(super) struct JniInterruptHandleImpl;
+
+impl<'a> JniInterruptHandle<'a> for JniInterruptHandleImpl {
+    type Error = errors::Error;
+
+    fn interrupt(env: &JNIEnv, this: JObject) -> Result<(), Self::Error> {
+        let interrupt_handle = interop::get_inner::<InterruptHandle>(&env, this)?;
+        interrupt_handle.interrupt();
+        Ok(())
+    }
+}

--- a/wasmtime-jni/src/io_github_kawamuray_wasmtime_InterruptHandle/mod.rs
+++ b/wasmtime-jni/src/io_github_kawamuray_wasmtime_InterruptHandle/mod.rs
@@ -1,0 +1,37 @@
+// THIS FILE IS GENERATED AUTOMATICALLY. DO NOT EDIT!
+mod imp;
+
+use self::imp::JniInterruptHandleImpl;
+use jni::descriptors::Desc;
+use jni::objects::*;
+use jni::sys::*;
+use jni::JNIEnv;
+
+macro_rules! wrap_error {
+    ($env:expr, $body:expr, $default:expr) => {
+        match $body {
+            Ok(v) => v,
+            Err(e) => {
+                $env.throw(e).expect("error in throwing exception");
+                $default
+            }
+        }
+    };
+}
+
+trait JniInterruptHandle<'a> {
+    type Error: Desc<'a, JThrowable<'a>>;
+    fn interrupt(env: &JNIEnv, this: JObject) -> Result<(), Self::Error>;
+}
+
+#[no_mangle]
+extern "system" fn Java_io_github_kawamuray_wasmtime_InterruptHandle_interrupt(
+    env: JNIEnv,
+    this: JObject,
+) {
+    wrap_error!(
+        env,
+        JniInterruptHandleImpl::interrupt(&env, this),
+        Default::default()
+    )
+}

--- a/wasmtime-jni/src/io_github_kawamuray_wasmtime_InterruptHandle/mod.rs
+++ b/wasmtime-jni/src/io_github_kawamuray_wasmtime_InterruptHandle/mod.rs
@@ -21,7 +21,20 @@ macro_rules! wrap_error {
 
 trait JniInterruptHandle<'a> {
     type Error: Desc<'a, JThrowable<'a>>;
+    fn dispose(env: &JNIEnv, this: JObject) -> Result<(), Self::Error>;
     fn interrupt(env: &JNIEnv, this: JObject) -> Result<(), Self::Error>;
+}
+
+#[no_mangle]
+extern "system" fn Java_io_github_kawamuray_wasmtime_InterruptHandle_dispose(
+    env: JNIEnv,
+    this: JObject,
+) {
+    wrap_error!(
+        env,
+        JniInterruptHandleImpl::dispose(&env, this),
+        Default::default()
+    )
 }
 
 #[no_mangle]

--- a/wasmtime-jni/src/io_github_kawamuray_wasmtime_Store/imp.rs
+++ b/wasmtime-jni/src/io_github_kawamuray_wasmtime_Store/imp.rs
@@ -5,7 +5,7 @@ use crate::store::StoreData;
 use jni::objects::{JClass, JObject};
 use jni::sys::*;
 use jni::{self, JNIEnv};
-use wasmtime::{Engine, Store};
+use wasmtime::{Engine, InterruptHandle, Store};
 use wasmtime_wasi::WasiCtx;
 
 pub(super) struct JniStoreImpl;
@@ -60,5 +60,11 @@ impl<'a> JniStore<'a> for JniStoreImpl {
         let mut store = interop::get_inner::<Store<StoreData>>(&env, this)?;
         store.gc();
         Ok(())
+    }
+
+    fn interrupt_handle_ptr(env: &JNIEnv, this: JObject) -> Result<jlong, Self::Error> {
+        let store = interop::get_inner::<Store<StoreData>>(&env, this)?;
+        let interrupt_handle = store.interrupt_handle()?;
+        Ok(interop::into_raw::<InterruptHandle>(interrupt_handle))
     }
 }

--- a/wasmtime-jni/src/io_github_kawamuray_wasmtime_Store/mod.rs
+++ b/wasmtime-jni/src/io_github_kawamuray_wasmtime_Store/mod.rs
@@ -24,6 +24,7 @@ trait JniStore<'a> {
     fn dispose(env: &JNIEnv, this: JObject) -> Result<(), Self::Error>;
     fn engine_ptr(env: &JNIEnv, this: JObject) -> Result<jlong, Self::Error>;
     fn gc(env: &JNIEnv, this: JObject) -> Result<(), Self::Error>;
+    fn interrupt_handle_ptr(env: &JNIEnv, this: JObject) -> Result<jlong, Self::Error>;
     fn new_store(
         env: &JNIEnv,
         clazz: JClass,
@@ -54,6 +55,18 @@ extern "system" fn Java_io_github_kawamuray_wasmtime_Store_enginePtr(
 #[no_mangle]
 extern "system" fn Java_io_github_kawamuray_wasmtime_Store_gc(env: JNIEnv, this: JObject) {
     wrap_error!(env, JniStoreImpl::gc(&env, this), Default::default())
+}
+
+#[no_mangle]
+extern "system" fn Java_io_github_kawamuray_wasmtime_Store_interruptHandlePtr(
+    env: JNIEnv,
+    this: JObject,
+) -> jlong {
+    wrap_error!(
+        env,
+        JniStoreImpl::interrupt_handle_ptr(&env, this),
+        Default::default()
+    )
 }
 
 #[no_mangle]

--- a/wasmtime-jni/src/lib.rs
+++ b/wasmtime-jni/src/lib.rs
@@ -13,6 +13,8 @@ mod io_github_kawamuray_wasmtime_Func;
 #[allow(non_snake_case)]
 mod io_github_kawamuray_wasmtime_Instance;
 #[allow(non_snake_case)]
+mod io_github_kawamuray_wasmtime_InterruptHandle;
+#[allow(non_snake_case)]
 mod io_github_kawamuray_wasmtime_Linker;
 #[allow(non_snake_case)]
 mod io_github_kawamuray_wasmtime_Memory;


### PR DESCRIPTION
Basic support for interrupt handlers. The `Store` can create the interrupt handler by itself so I changed the constructor to take an already existing ptr