### PR TITLE
Add convenience methods for enumerating externs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build
 # IntelliJ IDEA
 .idea/*
 !.idea/copyright
+# VSCode
+bin/

--- a/src/main/java/io/github/kawamuray/wasmtime/ExternItem.java
+++ b/src/main/java/io/github/kawamuray/wasmtime/ExternItem.java
@@ -1,0 +1,22 @@
+package io.github.kawamuray.wasmtime;
+
+public class ExternItem {
+
+	private final String name;
+
+	private final Extern extern;
+
+	public ExternItem(String name, Extern extern) {
+		this.name = name;
+		this.extern = extern;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public Extern getExtern() {
+		return extern;
+	}
+	
+}

--- a/src/main/java/io/github/kawamuray/wasmtime/Linker.java
+++ b/src/main/java/io/github/kawamuray/wasmtime/Linker.java
@@ -1,6 +1,11 @@
 package io.github.kawamuray.wasmtime;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -29,6 +34,22 @@ public class Linker implements Disposable {
         return Optional.ofNullable(nativeGet(store.innerPtr(), module, name));
     }
 
+    public <T> Map<String, Extern> getAll(Store<T> store, String module) {
+        Map<String, Extern> map = new HashMap<>();
+        for (String name : nativeExterns(store.innerPtr(), module)) {
+            try {
+                map.put(name, nativeGet(store.innerPtr(), module, name));
+            } catch(Exception e) {
+                // ignore native errors for externs of unimplemented type
+            }
+        }
+        return map;
+    }
+
+    public <T> Set<String> modules(Store<T> store) {
+        return new HashSet<>(Arrays.asList(nativeModules(store.innerPtr())));
+    }
+
     @Override
     public native void dispose();
 
@@ -39,4 +60,8 @@ public class Linker implements Disposable {
     private native void nativeDefine(String moduleName, String name, Extern externItem);
 
     private native Extern nativeGet(long storePtr, String module, String name);
+
+    private native String[] nativeExterns(long storePtr, String module);
+
+    private native String[] nativeModules(long storePtr);
 }

--- a/src/test/java/io/github/kawamuray/wasmtime/LinkerTest.java
+++ b/src/test/java/io/github/kawamuray/wasmtime/LinkerTest.java
@@ -1,0 +1,39 @@
+package io.github.kawamuray.wasmtime;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class LinkerTest {
+    private static final byte[] WAT_BYTES_ADD = ("(module"
+            + "  (func (export \"add\") (param $p1 i32) (param $p2 i32) (result i32)"
+            + "    local.get $p1"
+            + "    local.get $p2"
+            + "    i32.add)"
+            + ')').getBytes();
+
+    @Test
+    public void testModules() {
+        try (Store<Void> store = Store.withoutData();
+             Linker linker = new Linker(store.engine());
+             Engine engine = store.engine();
+             Module module = new Module(engine, WAT_BYTES_ADD)) {
+            linker.module(store, "", module);
+            assertEquals(1, linker.modules(store).size());
+            assertEquals("", linker.modules(store).iterator().next());
+        }
+    }
+
+    @Test
+    public void testGetAll() {
+        try (Store<Void> store = Store.withoutData();
+             Linker linker = new Linker(store.engine());
+             Engine engine = store.engine();
+             Module module = new Module(engine, WAT_BYTES_ADD)) {
+            linker.module(store, "", module);
+            assertEquals(1, linker.getAll(store, "").size());
+            assertEquals("add", linker.getAll(store, "").keySet().iterator().next());
+        }
+    }
+
+}

--- a/src/test/java/io/github/kawamuray/wasmtime/LinkerTest.java
+++ b/src/test/java/io/github/kawamuray/wasmtime/LinkerTest.java
@@ -31,8 +31,8 @@ public class LinkerTest {
              Engine engine = store.engine();
              Module module = new Module(engine, WAT_BYTES_ADD)) {
             linker.module(store, "", module);
-            assertEquals(1, linker.getAll(store, "").size());
-            assertEquals("add", linker.getAll(store, "").keySet().iterator().next());
+            assertEquals(1, linker.externs(store, "").size());
+            assertEquals("add", linker.externs(store, "").iterator().next().getName());
         }
     }
 

--- a/wasmtime-jni/src/io_github_kawamuray_wasmtime_Linker/imp.rs
+++ b/wasmtime-jni/src/io_github_kawamuray_wasmtime_Linker/imp.rs
@@ -78,13 +78,13 @@ impl<'a> JniLinker<'a> for JniLinkerImpl {
         let module = utils::get_string(env, *module)?;
         let mut vec: Vec<String> = Vec::new();
         for item in linker.iter(&mut *store) {
-            if item.0.eq(&module) {
+            if item.0 == &module {
                 vec.push(item.1.to_string())
             }
         }
         let ret = env.new_object_array(vec.len() as i32, "java/lang/Object", JObject::null())?;
         for (i, item) in vec.iter().enumerate() {
-            let value: JString = env.new_string(item).unwrap().into();
+            let value: JString = env.new_string(item)?;
             env.set_object_array_element(ret, i as jsize, JObject::from(value))?;
         }
         Ok(ret.into())

--- a/wasmtime-jni/src/io_github_kawamuray_wasmtime_Linker/mod.rs
+++ b/wasmtime-jni/src/io_github_kawamuray_wasmtime_Linker/mod.rs
@@ -29,6 +29,12 @@ trait JniLinker<'a> {
         name: JString,
         extern_item: JObject,
     ) -> Result<(), Self::Error>;
+    fn native_externs(
+        env: &JNIEnv,
+        this: JObject,
+        store_ptr: jlong,
+        module: JString,
+    ) -> Result<jobjectArray, Self::Error>;
     fn native_get(
         env: &JNIEnv,
         this: JObject,
@@ -43,6 +49,11 @@ trait JniLinker<'a> {
         module_name: JString,
         module_ptr: jlong,
     ) -> Result<(), Self::Error>;
+    fn native_modules(
+        env: &JNIEnv,
+        this: JObject,
+        store_ptr: jlong,
+    ) -> Result<jobjectArray, Self::Error>;
     fn new_linker(env: &JNIEnv, clazz: JClass, engine_ptr: jlong) -> Result<jlong, Self::Error>;
 }
 
@@ -63,6 +74,20 @@ extern "system" fn Java_io_github_kawamuray_wasmtime_Linker_nativeDefine(
         env,
         JniLinkerImpl::native_define(&env, this, module_name, name, extern_item),
         Default::default()
+    )
+}
+
+#[no_mangle]
+extern "system" fn Java_io_github_kawamuray_wasmtime_Linker_nativeExterns(
+    env: JNIEnv,
+    this: JObject,
+    store_ptr: jlong,
+    module: JString,
+) -> jobjectArray {
+    wrap_error!(
+        env,
+        JniLinkerImpl::native_externs(&env, this, store_ptr, module),
+        JObject::null().into_inner()
     )
 }
 
@@ -93,6 +118,19 @@ extern "system" fn Java_io_github_kawamuray_wasmtime_Linker_nativeModule(
         env,
         JniLinkerImpl::native_module(&env, this, store_ptr, module_name, module_ptr),
         Default::default()
+    )
+}
+
+#[no_mangle]
+extern "system" fn Java_io_github_kawamuray_wasmtime_Linker_nativeModules(
+    env: JNIEnv,
+    this: JObject,
+    store_ptr: jlong,
+) -> jobjectArray {
+    wrap_error!(
+        env,
+        JniLinkerImpl::native_modules(&env, this, store_ptr),
+        JObject::null().into_inner()
     )
 }
 


### PR DESCRIPTION
It's useful to be able to list and inspect the externs (exports)
in a module. The linker has all the information it needs but it
wasn't exposing it to Java clients until this change.