### PR TITLE
Make externs into mutable collection before filtering

### DIFF
--- a/src/main/java/io/github/kawamuray/wasmtime/Linker.java
+++ b/src/main/java/io/github/kawamuray/wasmtime/Linker.java
@@ -41,7 +41,7 @@ public class Linker implements Disposable {
     }
 
     public <T> Collection<ExternItem> externsOfModule(Store<T> store, String module) {
-        Collection<ExternItem> items = externs(store);
+        Collection<ExternItem> items = new HashSet<>(externs(store));
         items.removeIf(item -> !item.module().equals(module));
         return items;
     }

--- a/src/test/java/io/github/kawamuray/wasmtime/LinkerTest.java
+++ b/src/test/java/io/github/kawamuray/wasmtime/LinkerTest.java
@@ -8,18 +8,22 @@ import org.junit.Test;
 
 public class LinkerTest {
     private static final byte[] WAT_BYTES_ADD = ("(module"
-                                                 + "  (func (export \"add\") (param $p1 i32) (param $p2 i32) (result i32)"
-                                                 + "    local.get $p1"
-                                                 + "    local.get $p2"
-                                                 + "    i32.add)"
-                                                 + ')').getBytes();
+            + "  (func (export \"add\") (param $p1 i32) (param $p2 i32) (result i32)"
+            + "    local.get $p1"
+            + "    local.get $p2"
+            + "    i32.add)"
+            + ')').getBytes();
+
+    private static final byte[] WAT_BYTES_TABLE = ("(module"
+            + "  (table (;0;) 8 8 funcref)(export \"__indirect_function_table\" (table 0))"
+            + ')').getBytes();
 
     @Test
     public void testModules() {
         try (Store<Void> store = Store.withoutData();
-             Linker linker = new Linker(store.engine());
-             Engine engine = store.engine();
-             Module module = new Module(engine, WAT_BYTES_ADD)) {
+                Linker linker = new Linker(store.engine());
+                Engine engine = store.engine();
+                Module module = new Module(engine, WAT_BYTES_ADD)) {
             linker.module(store, "", module);
             assertEquals(1, linker.modules(store).size());
             assertEquals("", linker.modules(store).iterator().next());
@@ -29,9 +33,9 @@ public class LinkerTest {
     @Test
     public void testExterns() {
         try (Store<Void> store = Store.withoutData();
-             Linker linker = new Linker(store.engine());
-             Engine engine = store.engine();
-             Module module = new Module(engine, WAT_BYTES_ADD)) {
+                Linker linker = new Linker(store.engine());
+                Engine engine = store.engine();
+                Module module = new Module(engine, WAT_BYTES_ADD)) {
             linker.module(store, "", module);
             Collection<ExternItem> externs = linker.externs(store);
             assertEquals(1, externs.size());
@@ -42,13 +46,44 @@ public class LinkerTest {
     @Test
     public void testExternsOfModule() {
         try (Store<Void> store = Store.withoutData();
-             Linker linker = new Linker(store.engine());
-             Engine engine = store.engine();
-             Module module = new Module(engine, WAT_BYTES_ADD)) {
+                Linker linker = new Linker(store.engine());
+                Engine engine = store.engine();
+                Module module = new Module(engine, WAT_BYTES_ADD)) {
             linker.module(store, "", module);
             Collection<ExternItem> externs = linker.externsOfModule(store, "");
             assertEquals(1, externs.size());
             assertEquals("add", externs.iterator().next().name());
         }
     }
+
+    @Test
+    public void testTableType() {
+        try (Store<Void> store = Store.withoutData();
+                Linker linker = new Linker(store.engine());
+                Engine engine = store.engine();
+                Module module = new Module(engine, WAT_BYTES_TABLE)) {
+            linker.module(store, "", module);
+            Collection<ExternItem> externs = linker.externs(store);
+            assertEquals(1, externs.size());
+            ExternItem item = externs.iterator().next();
+            assertEquals("__indirect_function_table", item.name());
+            // TODO: should be TABLE
+            assertEquals(Extern.Type.UNKNOWN, item.extern().type());
+        }
+    }
+
+    @Test
+    public void testExternsOfMulti() {
+        try (Store<Void> store = Store.withoutData();
+                Linker linker = new Linker(store.engine());
+                Engine engine = store.engine();
+                Module module = new Module(engine, WAT_BYTES_ADD)) {
+            linker.module(store, "", module);
+            linker.module(store, "other", new Module(engine, WAT_BYTES_TABLE));
+            Collection<ExternItem> externs = linker.externsOfModule(store, "");
+            assertEquals(1, externs.size());
+            assertEquals("add", externs.iterator().next().name());
+        }
+    }
+
 }


### PR DESCRIPTION
Arrays.asList() is immutable so there is an error at runtime if
we don't do this.

I also added a TODO highlighting another possible bug: the type
of some externs shows up as UNKNOWN.