### PR TITLE
added arch to dynamic library name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,7 +170,7 @@ task copyJniLib(type: Copy) {
     def targetDir = rustTargetTriple() ?: ""
     from "wasmtime-jni/target/$targetDir/release"
     include '*.so', '*.dylib', "*.dll"
-    rename "^(lib)?wasmtime_jni", "\$1wasmtime_jni_${project.version}_${jniLibOsClassifier()}"
+    rename "^(lib)?wasmtime_jni", "\$1wasmtime_jni_${project.version}_${jniLibOsClassifier()}_${System.getProperty("os.arch")}"
     into new File(project.buildDir, "jni-libs")
 }
 

--- a/src/main/java/io/github/kawamuray/wasmtime/NativeLibraryLoader.java
+++ b/src/main/java/io/github/kawamuray/wasmtime/NativeLibraryLoader.java
@@ -60,7 +60,8 @@ public final class NativeLibraryLoader {
         Platform platform = detectPlatform();
         String version = libVersion();
         String ext = platform.ext;
-        String fileName = platform.prefix + NATIVE_LIBRARY_NAME + '_' + version + '_' + platform.classifier;
+        String arch = System.getProperty("os.arch");
+        String fileName = platform.prefix + NATIVE_LIBRARY_NAME + '_' + version + '_' + platform.classifier + "_" + arch;
         Path tempFile = Files.createTempFile(fileName, ext);
         try (InputStream in = NativeLibraryLoader.class.getResourceAsStream('/' + fileName + ext)) {
             Files.copy(in, tempFile, StandardCopyOption.REPLACE_EXISTING);


### PR DESCRIPTION
I added the system arch to the dynamic library file name. Arch is found using `System.getProperty("os.arch")`. This fetches the architecture of the JVM running the java code.

This will make it easier to add additional JNI builds in the future, and avoid name conflicts when the architectures differ but the os is the same.

Note that I can't test this on my local machine because the master branch doesn't build.

```
Execution failed for task ':compileJava'.
> java.lang.IllegalAccessError: class lombok.javac.apt.LombokProcessor (in unnamed module @0x64c9ad8b) cannot access class com.sun.tools.javac.processing.JavacProcessingEnvironment (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.processing to unnamed module @0x64c9ad8b
```