### PR TITLE
Use Ubuntu 18.04 to link against an older versions of glibc for compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-18.04, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8


### PR DESCRIPTION
The current published JNI build requires glibc >= 2.32 to be installed, otherwise you get this error:
```
java.lang.UnsatisfiedLinkError: /tmp/libwasmtime_jni_0.14.0_linux12559640904482558164.so: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /tmp/libwasmtime_jni_0.14.0_linux12559640904482558164.so)
```
From our testing, we've found that just building against an older version of glibc will result in a more compatible build, since later installs will still include support for the older glibc versions. The easiest way to do that is to use the older `ubuntu-18.04` runner, which will result in linking against `GLIBC_2.27`. I've included a debug step here to show that, but I'm happy to remove it if required.

I've tested this out myself via a local actions runner and it doesn't seem to introduce any incompatibilities. In order to actually depend on the resulting build from our library however, it's much simpler to have a new release made from this project, instead of a manually included JAR.