### PR TITLE
Improve GLIBC compatibility and fix build issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,21 +57,13 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: Set up Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly-2022-12-11
-        override: true
-        components: rustfmt
-    - name: Build
-      run: ./gradlew build
     - name: Restore JNI libs
       uses: actions/download-artifact@v2
       with:
         name: jni-libs
         path: build/jni-libs
     - name: Build universal jar
-      run: ./gradlew universalJar
+      run: ./gradlew universalJar -x buildJniLib -x copyJniLib
     - name: Create release
       id: create_release
       uses: actions/create-release@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
         components: rustfmt
     # Binary compatibility settings from bytecodealliance/wasmtime
     - name: Binary compatibility settings (macOS)
-      if: ${{ !startsWith(matrix.os, 'macos') }}
+      if: ${{ startsWith(matrix.os, 'macos') }}
       run: echo 'MACOSX_DEPLOYMENT_TARGET=10.9' >> $GITHUB_ENV
     - name: Binary compatibility settings (Windows)
-      if: ${{ !startsWith(matrix.os, 'windows') }}
+      if: ${{ startsWith(matrix.os, 'windows') }}
       run: echo 'RUSTFLAGS=-Ctarget-feature=+crt-static' >> $GITHUB_ENV
     # Run gradle normally to build the JNI lib
     - name: Build with Gradle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,13 @@ jobs:
         override: true
         components: rustfmt
     - name: Build with Gradle
+      if: ${{ !startsWith(matrix.os, 'ubuntu') }}
       run: ./gradlew build copyJniLib
+    - name: Build with Gradle (Linux)
+      if: ${{ startsWith(matrix.os, 'ubuntu') }}
+      run: |
+        docker build -t build-image ./ci/docker/x86_64-linux
+        docker run --rm --volume $PWD:/build --workdir /build build-image ./gradlew build copyJniLib -x javadoc
     - name: Save JNI lib output
       if: startsWith(github.ref, 'refs/tags/')
       uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,18 @@ jobs:
         toolchain: nightly-2022-12-11
         override: true
         components: rustfmt
+    # Binary compatibility settings from bytecodealliance/wasmtime
+    - name: Binary compatibility settings (macOS)
+      if: ${{ !startsWith(matrix.os, 'macos') }}
+      run: echo 'MACOSX_DEPLOYMENT_TARGET=10.9' >> $GITHUB_ENV
+    - name: Binary compatibility settings (Windows)
+      if: ${{ !startsWith(matrix.os, 'windows') }}
+      run: echo 'RUSTFLAGS=-Ctarget-feature=+crt-static' >> $GITHUB_ENV
+    # Run gradle normally to build the JNI lib
     - name: Build with Gradle
       if: ${{ !startsWith(matrix.os, 'ubuntu') }}
       run: ./gradlew build copyJniLib
+    # Run gradle in a docker container to build the JNI lib on Linux for old glibc compatibility
     - name: Build with Gradle (Linux)
       if: ${{ startsWith(matrix.os, 'ubuntu') }}
       run: |

--- a/ci/docker/x86_64-linux/Dockerfile
+++ b/ci/docker/x86_64-linux/Dockerfile
@@ -1,0 +1,13 @@
+FROM centos:7
+
+ARG TOOLCHAIN=nightly-2022-12-11
+
+RUN yum install -y git gcc java-11-openjdk
+
+ENV PATH=$PATH:/rust/bin:/root/.cargo/bin
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-11.0.19.0.7-1.el7_9.x86_64
+
+# Install rustup
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=${TOOLCHAIN} --profile=minimal && rustc --version
+RUN rustup component add rustfmt
+


### PR DESCRIPTION
This is a follow-up to #49 that fixes an issue with those changes, plus improves compatibility further using a few tricks borrowed from the core bytecodealliance/wasmtime build.
- The publish step was replacing the compatible shared lib before building a universal JAR - this avoids rebuilding it by skipping those gradle tasks manually
- To maximize glibc compatibility, we run the gradle build for linux in a `centos:7` docker container, similar to https://github.com/bytecodealliance/wasmtime/tree/main/.github/actions/binary-compatible-builds
- The [macOS and Windows build tweaks](https://github.com/kawamuray/wasmtime-java/commit/6d17c3513bbb82f12ddf976c751e173fa6cb0e37) were copied from the wasmtime build as well - I don't know much about the consequences of these options though so if they're not 100% safe I'm happy to drop them.

I've tested this on my own fork, and it appears to work for all platforms and not slow down the build too significantly. The bugfix in the publish step also speeds up the build by avoiding rebuilding of the shared lib.

The result of this change is that glibc >= 2.14 is supported (was 2.34 previously).