### PR TITLE
Build shared library for Apple Silicon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,14 @@ jobs:
       if: matrix.target != ''
     # Run gradle normally to build the JNI lib
     - name: Build with Gradle
-      if: ${{ !startsWith(matrix.os, 'ubuntu') }}
+      if: ${{ startsWith(matrix.os, 'windows') }}
       run: ./gradlew build copyJniLib
+    - name: Build with Gradle (x86_64-macos)
+      if: matrix.build == 'x86_64-macos'
+      run: ./gradlew build copyJniLib
+    - name: Build with Gradle (aarch64-macos)
+      if: matrix.build == 'aarch64-macos'
+      run: ./gradlew build copyJniLib -x test
     # Run gradle in a docker container to build the JNI lib on Linux for old glibc compatibility
     - name: Build with Gradle (Linux)
       if: ${{ startsWith(matrix.os, 'ubuntu') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
     - name: Build with Gradle
       if: ${{ !startsWith(matrix.os, 'ubuntu') }}
       run: ./gradlew build copyJniLib ${GRADLE_ARGS}
+    - name: List shared library files
+      run:
+        ls -lt build/jni-libs
     - name: Save JNI lib output
       if: startsWith(github.ref, 'refs/tags/')
       uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,27 +42,22 @@ jobs:
       if: ${{ startsWith(matrix.os, 'windows') }}
       run: echo 'RUSTFLAGS=-Ctarget-feature=+crt-static' >> $GITHUB_ENV
     - name: Set build target for cross-compiling
+      if: matrix.target != ''
       run: |
         echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
         echo JNILIB_RUST_TARGET=${{ matrix.target }} >> $GITHUB_ENV
+        echo GRADLE_ARGS="${GRADLE_ARGS} -x test">> $GITHUB_ENV
         rustup target add ${{ matrix.target }}
-      if: matrix.target != ''
-    # Run gradle normally to build the JNI lib
-    - name: Build with Gradle
-      if: ${{ startsWith(matrix.os, 'windows') }}
-      run: ./gradlew build copyJniLib
-    - name: Build with Gradle (x86_64-macos)
-      if: matrix.build == 'x86_64-macos'
-      run: ./gradlew build copyJniLib
-    - name: Build with Gradle (aarch64-macos)
-      if: matrix.build == 'aarch64-macos'
-      run: ./gradlew build copyJniLib -x test
     # Run gradle in a docker container to build the JNI lib on Linux for old glibc compatibility
     - name: Build with Gradle (Linux)
       if: ${{ startsWith(matrix.os, 'ubuntu') }}
       run: |
         docker build -t build-image ./ci/docker/x86_64-linux
         docker run --rm --volume $PWD:/build --workdir /build build-image ./gradlew build copyJniLib -x javadoc
+    # Otherwise, run gradle normally to build the JNI lib
+    - name: Build with Gradle
+      if: ${{ !startsWith(matrix.os, 'ubuntu') }}
+      run: ./gradlew build copyJniLib ${GRADLE_ARGS}
     - name: Save JNI lib output
       if: startsWith(github.ref, 'refs/tags/')
       uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
       run:
         ls build/jni-libs
     - name: Save JNI lib output
+      if: startsWith(github.ref, 'refs/tags/')
       uses: actions/upload-artifact@v2
       with:
         name: jni-libs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,6 @@ jobs:
       run:
         ls -lt build/jni-libs
     - name: Save JNI lib output
-      if: startsWith(github.ref, 'refs/tags/')
       uses: actions/upload-artifact@v2
       with:
         name: jni-libs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       run: ./gradlew build copyJniLib ${GRADLE_ARGS}
     - name: List shared library files
       run:
-        ls -lt build/jni-libs
+        ls build/jni-libs
     - name: Save JNI lib output
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,20 @@ on:
     branches: [ master ]
 jobs:
   build:
+    name: Build JNI lib for ${{ matrix.build }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        include:
+          - build: x86_64-linux
+            os: ubuntu-latest
+          - build: x86_64-macos
+            os: macos-latest
+          - build: aarch64-macos
+            os: macos-latest
+            target: aarch64-apple-darwin
+          - build: x86_64-windows
+            os: windows-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8
@@ -31,6 +41,12 @@ jobs:
     - name: Binary compatibility settings (Windows)
       if: ${{ startsWith(matrix.os, 'windows') }}
       run: echo 'RUSTFLAGS=-Ctarget-feature=+crt-static' >> $GITHUB_ENV
+    - name: Set build target for cross-compiling
+      run: |
+        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
+        echo JNILIB_RUST_TARGET=${{ matrix.target }} >> $GITHUB_ENV
+        rustup target add ${{ matrix.target }}
+      if: matrix.target != ''
     # Run gradle normally to build the JNI lib
     - name: Build with Gradle
       if: ${{ !startsWith(matrix.os, 'ubuntu') }}

--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ dependencies {
 
 An artifact (JAR) of `wasmtime-java` ships along with prebuilt JNI libraries for some major platforms, so just adding the above dependency provides you a self-contained `wasmtime` runtime on supported platforms:
 
-| OS          | Arch   |
-| ----        | ----   |
-| Linux (ELF) | x86_64 |
-| Mac OS      | x86_64 |
-| Windows     | x86_64 |
+| OS          | Arch    |
+| ----        | ----    |
+| Linux (ELF) | x86_64  |
+| Mac OS      | x86_64  |
+| Mac OS      | aarch64 |
+| Windows     | x86_64  |
 
 # Example
 

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ test {
 static def jniLibOsClassifier() {
     def os = System.getProperty("os.name").toLowerCase()
     def arch = System.getProperty("os.arch").toLowerCase()
-    project.logger.lifecycle("jniLibOsClassifier: os=${os} arch=${arch}")
+    println "jniLibOsClassifier: os=${os} arch=${arch}"
 
     if (os.contains("linux")) {
         return "linux"

--- a/build.gradle
+++ b/build.gradle
@@ -59,11 +59,18 @@ test {
 
 static def jniLibOsClassifier() {
     def os = System.getProperty("os.name").toLowerCase()
+    def arch = System.getProperty("os.arch").toLowerCase()
+    project.logger.lifecycle("jniLibOsClassifier: os=${os} arch=${arch}")
+
     if (os.contains("linux")) {
         return "linux"
     }
     if (os.contains("mac os") || os.contains("darwin")) {
-        return "macos"
+        if (arch.equals("aarch64")) {
+            return "macos_aarch64"
+        } else {
+            return "macos"
+        }
     }
     if (os.contains("windows")){
         return "windows"

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,8 @@ static def jniLibOsClassifier() {
 
 static def jniLibArchClassifier() {
     def target = rustTargetTriple() ?: ""
-    return target ? "_" + target.split("-")[0] : ""
+    // Use the first part of the rust target triple as the arch classifier if set, otherwise assume "x86_64"
+    return target ? target.split("-")[0] : "x86_64"
 }
 
 static def rustTargetTriple() {
@@ -176,7 +177,7 @@ task copyJniLib(type: Copy) {
     def targetDir = rustTargetTriple() ?: ""
     from "wasmtime-jni/target/$targetDir/release"
     include '*.so', '*.dylib', "*.dll"
-    rename "^(lib)?wasmtime_jni", "\$1wasmtime_jni_${project.version}_${jniLibOsClassifier()}${jniLibArchClassifier()}"
+    rename "^(lib)?wasmtime_jni", "\$1wasmtime_jni_${project.version}_${jniLibOsClassifier()}_${jniLibArchClassifier()}"
     into new File(project.buildDir, "jni-libs")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -59,12 +59,6 @@ test {
 
 static def jniLibOsClassifier() {
     def os = System.getProperty("os.name").toLowerCase()
-    def target = rustTargetTriple() ?: ""
-
-    if (target != "") {
-        // use the arch part of the Rust target triple
-        return target.split("-")[0]
-    }
 
     if (os.contains("linux")) {
         return "linux"
@@ -76,6 +70,11 @@ static def jniLibOsClassifier() {
         return "windows"
     }
     throw new RuntimeException("platform not supported: " + System.getProperty("os.name"))
+}
+
+static def jniLibArchClassifier() {
+    def target = rustTargetTriple() ?: ""
+    return target ? "_" + target.split("-")[0] : ""
 }
 
 static def rustTargetTriple() {
@@ -177,7 +176,7 @@ task copyJniLib(type: Copy) {
     def targetDir = rustTargetTriple() ?: ""
     from "wasmtime-jni/target/$targetDir/release"
     include '*.so', '*.dylib', "*.dll"
-    rename "^(lib)?wasmtime_jni", "\$1wasmtime_jni_${project.version}_${jniLibOsClassifier()}"
+    rename "^(lib)?wasmtime_jni", "\$1wasmtime_jni_${project.version}_${jniLibOsClassifier()}${jniLibArchClassifier()}"
     into new File(project.buildDir, "jni-libs")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -59,18 +59,18 @@ test {
 
 static def jniLibOsClassifier() {
     def os = System.getProperty("os.name").toLowerCase()
-    def arch = System.getProperty("os.arch").toLowerCase()
-    println "jniLibOsClassifier: os=${os} arch=${arch}"
+    def target = rustTargetTriple() ?: ""
+
+    if (target != "") {
+        // use the arch part of the Rust target triple
+        return target.split("-")[0]
+    }
 
     if (os.contains("linux")) {
         return "linux"
     }
     if (os.contains("mac os") || os.contains("darwin")) {
-        if (arch.equals("aarch64")) {
-            return "macos_aarch64"
-        } else {
-            return "macos"
-        }
+        return "macos"
     }
     if (os.contains("windows")){
         return "windows"

--- a/src/main/java/io/github/kawamuray/wasmtime/NativeLibraryLoader.java
+++ b/src/main/java/io/github/kawamuray/wasmtime/NativeLibraryLoader.java
@@ -79,10 +79,10 @@ public final class NativeLibraryLoader {
 
     @AllArgsConstructor
     private enum Platform {
-        LINUX("linux","lib" , ".so"),
-        MACOS("macos","lib", ".dylib"),
-        WINDOWS("windows","",".dll")
-        ;
+        LINUX("linux", "lib", ".so"),
+        MACOS("macos", "lib", ".dylib"),
+        MACOS_AARCH64("macos_aarch64", "lib", ".dylib"),
+        WINDOWS("windows", "", ".dll");
 
         final String classifier;
         final String prefix;
@@ -91,13 +91,17 @@ public final class NativeLibraryLoader {
 
     private static Platform detectPlatform() {
         String os = System.getProperty("os.name").toLowerCase();
+        String arch = System.getProperty("os.arch").toLowerCase();
         if (os.contains("linux")) {
             return Platform.LINUX;
         }
         if (os.contains("mac os") || os.contains("darwin")) {
+            if (arch.equals("aarch64")) {
+                return Platform.MACOS_AARCH64;
+            }
             return Platform.MACOS;
         }
-        if(os.toLowerCase().contains("windows")){
+        if (os.toLowerCase().contains("windows")) {
             return Platform.WINDOWS;
         }
         throw new RuntimeException("platform not supported: " + os);

--- a/src/main/java/io/github/kawamuray/wasmtime/NativeLibraryLoader.java
+++ b/src/main/java/io/github/kawamuray/wasmtime/NativeLibraryLoader.java
@@ -60,7 +60,7 @@ public final class NativeLibraryLoader {
         Platform platform = detectPlatform();
         String version = libVersion();
         String ext = platform.ext;
-        String fileName = platform.prefix + NATIVE_LIBRARY_NAME + '_' + version + '_' + platform.classifier;
+        String fileName = platform.prefix + NATIVE_LIBRARY_NAME + '_' + version + '_' + platform.os.value + '_' + platform.arch.value;
         Path tempFile = Files.createTempFile(fileName, ext);
         try (InputStream in = NativeLibraryLoader.class.getResourceAsStream('/' + fileName + ext)) {
             Files.copy(in, tempFile, StandardCopyOption.REPLACE_EXISTING);
@@ -70,7 +70,7 @@ public final class NativeLibraryLoader {
 
     private static String libVersion() throws IOException {
         final Properties props;
-        try (InputStream in = NativeLibraryLoader.class.getResourceAsStream( '/' + META_PROPS_FILE)) {
+        try (InputStream in = NativeLibraryLoader.class.getResourceAsStream('/' + META_PROPS_FILE)) {
             props = new Properties();
             props.load(in);
         }
@@ -78,13 +78,31 @@ public final class NativeLibraryLoader {
     }
 
     @AllArgsConstructor
-    private enum Platform {
-        LINUX("linux", "lib", ".so"),
-        MACOS("macos", "lib", ".dylib"),
-        MACOS_AARCH64("macos_aarch64", "lib", ".dylib"),
-        WINDOWS("windows", "", ".dll");
+    private enum Os {
+        LINUX("linux"),
+        MACOS("macos"),
+        WINDOWS("windows");
 
-        final String classifier;
+        final String value;
+    }
+
+    @AllArgsConstructor
+    private enum Arch {
+        X86_64("x86_64"),
+        AARCH64("aarch64");
+
+        final String value;
+    }
+
+    @AllArgsConstructor
+    private enum Platform {
+        LINUX(Os.LINUX, Arch.X86_64, "lib", ".so"),
+        MACOS(Os.MACOS, Arch.X86_64, "lib", ".dylib"),
+        MACOS_AARCH64(Os.MACOS, Arch.AARCH64, "lib", ".dylib"),
+        WINDOWS(Os.WINDOWS, Arch.X86_64, "", ".dll");
+
+        final Os os;
+        final Arch arch;
         final String prefix;
         final String ext;
     }


### PR DESCRIPTION
This adds support for an `aarch64` build of the shared library, and updates the NativeLibraryLoader to load it on macOS when the `os.arch` system property is `aarch64`.

Although it's pretty straightforward to build for this architecture, running the tests is a lot more complex so I've disabled them when cross-compiling for now. It looks like [bytecodealliance/wasmtime](https://github.com/bytecodealliance/wasmtime) uses qemu to solve this problem for some architectures, but it's not as simple as just setting a target.