### PR TITLE
Support aarch64-linux for docker on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,11 @@ jobs:
         include:
           - build: x86_64-linux
             os: ubuntu-latest
+            docker: true
+          - build: aarch64-linux
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            docker: true
           - build: x86_64-macos
             os: macos-latest
           - build: aarch64-macos
@@ -44,23 +49,30 @@ jobs:
     - name: Set build target for cross-compiling
       if: matrix.target != ''
       run: |
-        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
-        echo JNILIB_RUST_TARGET=${{ matrix.target }} >> $GITHUB_ENV
-        echo GRADLE_ARGS="${GRADLE_ARGS} -x test">> $GITHUB_ENV
+        echo CARGO_BUILD_TARGET=${{ matrix.target }} >> build_env.txt
+        echo JNILIB_RUST_TARGET=${{ matrix.target }} >> build_env.txt
+        echo GRADLE_ARGS="${GRADLE_ARGS} -x test">> build_env.txt
+        cat build_env.txt >> $GITHUB_ENV
         rustup target add ${{ matrix.target }}
     # Run gradle in a docker container to build the JNI lib on Linux for old glibc compatibility
     - name: Build with Gradle (Linux)
-      if: ${{ startsWith(matrix.os, 'ubuntu') }}
+      if: ${{ matrix.docker }}
       run: |
-        docker build -t build-image ./ci/docker/x86_64-linux
-        docker run --rm --volume $PWD:/build --workdir /build build-image ./gradlew build copyJniLib -x javadoc
+        if [ ! -e build_env.txt ]; then
+          touch build_env.txt
+        fi
+        docker build -t build-image ./ci/docker/${{ matrix.build }}
+        docker run --rm --volume $PWD:/build --workdir /build \
+          --env-file build_env.txt \
+          build-image \
+          ./gradlew build copyJniLib -x javadoc ${GRADLE_ARGS}
     # Otherwise, run gradle normally to build the JNI lib
     - name: Build with Gradle
-      if: ${{ !startsWith(matrix.os, 'ubuntu') }}
+      if: ${{ !matrix.docker }}
       run: ./gradlew build copyJniLib ${GRADLE_ARGS}
     - name: List shared library files
       run:
-        ls build/jni-libs
+        file build/jni-libs/*
     - name: Save JNI lib output
       if: startsWith(github.ref, 'refs/tags/')
       uses: actions/upload-artifact@v2

--- a/ci/docker/aarch64-linux/.cargo_config
+++ b/ci/docker/aarch64-linux/.cargo_config
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/ci/docker/aarch64-linux/Dockerfile
+++ b/ci/docker/aarch64-linux/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:16.04
+
+ARG TOOLCHAIN=nightly-2022-12-11
+
+RUN apt-get update && apt-get install -y curl git gcc openjdk-8-jdk-headless gcc-aarch64-linux-gnu ca-certificates
+
+ENV PATH=$PATH:/rust/bin:/root/.cargo/bin
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+ENV CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu
+ENV JNILIB_RUST_TARGET=aarch64-unknown-linux-gnu
+
+# Confirm that the JAVA_HOME var is set correctly
+RUN ls ${JAVA_HOME}/bin/java
+
+# Install rustup
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=${TOOLCHAIN} --profile=minimal && rustc --version
+RUN rustup component add rustfmt
+
+RUN rustup target add ${CARGO_BUILD_TARGET}
+
+# Workaround for https://github.com/rust-lang/cargo/issues/4133
+# Linker tool needs to be specified explicitly
+COPY .cargo_config /root/.cargo/config

--- a/ci/docker/x86_64-linux/Dockerfile
+++ b/ci/docker/x86_64-linux/Dockerfile
@@ -5,9 +5,11 @@ ARG TOOLCHAIN=nightly-2022-12-11
 RUN yum install -y git gcc java-11-openjdk
 
 ENV PATH=$PATH:/rust/bin:/root/.cargo/bin
-ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-11.0.19.0.7-1.el7_9.x86_64
+ENV JAVA_HOME=/etc/alternatives/jre_11_openjdk
+
+# Confirm that the JAVA_HOME var is set correctly
+RUN ls ${JAVA_HOME}/bin/java
 
 # Install rustup
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain=${TOOLCHAIN} --profile=minimal && rustc --version
 RUN rustup component add rustfmt
-

--- a/src/main/java/io/github/kawamuray/wasmtime/NativeLibraryLoader.java
+++ b/src/main/java/io/github/kawamuray/wasmtime/NativeLibraryLoader.java
@@ -97,6 +97,7 @@ public final class NativeLibraryLoader {
     @AllArgsConstructor
     private enum Platform {
         LINUX(Os.LINUX, Arch.X86_64, "lib", ".so"),
+        LINUX_AARCH64(Os.LINUX, Arch.AARCH64, "lib", ".so"),
         MACOS(Os.MACOS, Arch.X86_64, "lib", ".dylib"),
         MACOS_AARCH64(Os.MACOS, Arch.AARCH64, "lib", ".dylib"),
         WINDOWS(Os.WINDOWS, Arch.X86_64, "", ".dll");
@@ -111,6 +112,9 @@ public final class NativeLibraryLoader {
         String os = System.getProperty("os.name").toLowerCase();
         String arch = System.getProperty("os.arch").toLowerCase();
         if (os.contains("linux")) {
+            if (arch.equals("aarch64")) {
+                return Platform.LINUX_AARCH64;
+            }
             return Platform.LINUX;
         }
         if (os.contains("mac os") || os.contains("darwin")) {


### PR DESCRIPTION
This adds a build configuration for aarch64-linux, which is used when running a Linux docker container on a aarch64 Mac.

A different docker image base is needed to get a aarch64 cross-compiler, and there's a small tradeoff in terms of GCC compatibility from using a newer image in this case (`ubuntu:16:04` vs `centos:7`).

I also fixed an issue that had appeared with the release build - the directory for JAVA_HOME in the docker image was too specific and changed along with the package being upgraded. It should be using a more generic symlinked directory now.